### PR TITLE
Export in ISO-8859-15 / html_entity_decode

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -56,6 +56,13 @@ class Config
     public function __construct(string $strTable = 'tl_member')
     {
         $this->arrData['table'] = $strTable;
+        $this->arrData['rowCallback'] = static function ($arrRow) {
+            foreach($arrRow as $fieldName => $varValue)
+            {
+                $arrRow[$fieldName] = is_string($varValue) ? utf8_decode(html_entity_decode($varValue)) : $varValue;
+            }
+            return $arrRow;
+        };
     }
 
     public function getModel(): ?ExportTableModel


### PR DESCRIPTION
Hi, I open this pull request to discuss about two functionalities :
- data are HTML-encoded
Because some tables contain html entities (for example, I have fields where parentheses are encoding in &# notation)
To be honest and correct, it should be determined by field.

- handle UTF-8
Because Excel don't expect UTF-8 files. It seems certain versions of Excel will handle them if they contain a BOM byte. So it could be a choice between adding a BOM, and UTF-8 decoding.
(Let's be honest : 99% of csv exports will be opened in MS Excel)

I agree this pull request is not functionnaly mergeable as is; it is not backward-compatible (and this decodings may not be wanted in certain circumstances); to do it properly, there should be options to control these behaviours.
This should maybe be 2 different requests.